### PR TITLE
Make search unique on keywords and document type

### DIFF
--- a/NateGoSearch/NateGoSearchQuery.php
+++ b/NateGoSearch/NateGoSearchQuery.php
@@ -234,7 +234,11 @@ class NateGoSearchQuery
 		$misspellings = $this->getPopularReplacements($keywords, $misspellings);
 
 		$keywords = $this->normalizeKeywordsForSearching($keywords);
-		$unique_hash = sha1($keywords.serialize($this->document_types));
+
+		$document_type_ids = array_values($this->document_types);
+		sort($document_type_ids);
+
+		$unique_hash = sha1($keywords.':'.implode('-', $document_type_ids));
 
 		$results = new NateGoSearchResult(
 			$this->db,

--- a/NateGoSearch/NateGoSearchQuery.php
+++ b/NateGoSearch/NateGoSearchQuery.php
@@ -234,10 +234,14 @@ class NateGoSearchQuery
 		$misspellings = $this->getPopularReplacements($keywords, $misspellings);
 
 		$keywords = $this->normalizeKeywordsForSearching($keywords);
-		$keywords_hash = sha1($keywords);
+		$unique_hash = sha1($keywords.serialize($this->document_types));
 
-		$results = new NateGoSearchResult($this->db, $id, $keywords,
-			$this->document_types);
+		$results = new NateGoSearchResult(
+			$this->db,
+			$id,
+			$keywords,
+			$this->document_types
+		);
 
 		$results->addMisspellings($misspellings);
 
@@ -263,7 +267,7 @@ class NateGoSearchQuery
 
 			$params = array(
 				$this->db->quote($keywords, 'text'),
-				$this->db->quote($keywords_hash, 'text'),
+				$this->db->quote($unique_hash, 'text'),
 				$this->quoteArray($this->document_types),
 				$this->db->quote($id, 'text'),
 			);


### PR DESCRIPTION
The hash is only used for saving the cache. The issue is that the current way breaks if you search two different groups of document types. The first search will cache against the first set of types, and the second search will come from the cache and have the wrong set of results.

See https://github.com/silverorange/nate-go-search/blob/master/sql/functions/nateGoSearch.sql#L64-L74