### PR TITLE
New lines were being replaced with a string instead of a new line

### DIFF
--- a/NateGoSearch/NateGoSearchIndexer.php
+++ b/NateGoSearch/NateGoSearchIndexer.php
@@ -615,8 +615,8 @@ class NateGoSearchIndexer
 		$text = strtolower($text);
 
 		// replace windows and mac style newlines with unix style newlines
-		$text = preg_replace('/\r\n/u', '\n', $text);
-		$text = preg_replace('/\r/u', '\n', $text);
+		$text = preg_replace('/\r\n/u', "\n", $text);
+		$text = preg_replace('/\r/u', "\n", $text);
 
 		// replace html/xhtml/xml tags with spaces
 		$text = preg_replace('/<\/?[^>]*>*/u', ' ', $text);


### PR DESCRIPTION
```
 Effect Of Using The HEART Score In Patients With Chest Pain In The Emergency Department: A Stepped-Wedge, Cluster Randomized Trial \r+
 Poldervaart, J.M., et al, Ann Intern Med 166(10):689, May 16, 2017
```
the word `Poldervaart` was being return as `\nPoldervaart` and indexed as `npoldervaart`
